### PR TITLE
Multi-architecture support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.5 AS builder
+FROM mirror.gcr.io/golang:1.24.5 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +15,7 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o custom-metrics-apiserver cmd/main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o custom-metrics-apiserver cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Overview

In order to allow building on different architectures (eg arm64) I removed the GOARCH definition - should be smart enough to use current architecture.

I also used mirror of gcr.io rather than docker.io since it has better licensing.

### Verification Steps
Build a multiarch image:
```shell
podman build --platform linux/arm64 -t custom-metrics-apiserver:latest-arm64 .
podman build --platform linux/amd64 -t custom-metrics-apiserver:latest-amd64 .
podman manifest create custom-metrics-apiserver:latest
podman manifest add custom-metrics-apiserver:latest custom-metrics-apiserver:latest-arm64
podman manifest add custom-metrics-apiserver:latest custom-metrics-apiserver:latest-amd64
podman manifest push custom-metrics-apiserver:latest quay.io/ORG/custom-metrics-apiserver:latest
```

Execute `./tools-install.sh` against a cluster (ideally both AMD64 and ARM64 based but AMD64 would be sufficient) using `quay.io/ORG/custom-metrics-apiserver:latest`
- this can be configured via `values-tools.yaml`.